### PR TITLE
Add missing `.siddhiext` file

### DIFF
--- a/component/src/main/resources/geo.siddhiext
+++ b/component/src/main/resources/geo.siddhiext
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2015-2016 WSO2 Inc. (http://wso2.com)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+within=org.wso2.extension.siddhi.gpl.execution.geo.function.GeoWithinFunctionExecutor
+intersects=org.wso2.extension.siddhi.gpl.execution.geo.function.GeoIntersectsFunctionExecutor
+withinDistance=org.wso2.extension.siddhi.gpl.execution.geo.function.GeoWithinDistanceFunctionExecutor
+crosses=org.wso2.extension.siddhi.gpl.execution.geo.stream.GeoCrossesStreamProcessor
+proximity=org.wso2.extension.siddhi.gpl.execution.geo.stream.GeoProximityStreamProcessor
+stationary=org.wso2.extension.siddhi.gpl.execution.geo.stream.GeoStationaryStreamProcessor
+closestPoints=org.wso2.extension.siddhi.gpl.execution.geo.stream.function.GeoClosestPointsStreamFunctionProcessor
+locationApproximate=org.wso2.extension.siddhi.gpl.execution.geo.stream.GeoLocationApproximateStreamProcessor
+distance=org.wso2.extension.siddhi.gpl.execution.geo.function.GeoDistanceFunctionExecutor


### PR DESCRIPTION
This extension when used with the example here https://ei.docs.wso2.com/en/latest/streaming-integrator/samples/GeoDistanceCalculation/ fails with the following error, 
```
WARN {org.wso2.carbon.streaming.integrator.core.internal.StreamProcessorDeployer} - Dependencies are not satisfied to deploy siddhi file GeoDistanceCalculation.siddhi due to Error on 'GeoDistanceCalculation' @ Line: 17. Position: 69, near 'geo:distance(latitude, longitude, prevLatitude, prevLongitude)'. 'distance' is neither a function extension nor an aggregated attribute extension.Please check the required dependencies exist.Redeploy will retry in 3000 milliseconds.
Tried using the `siddhi-gpl-execution-geo-4.0.9.jar` and also the `siddhi-execution-geo-5.0.1.jar` which was built by building the repo.
```

This is because the `.siddhiext` file is missing. This file was available previously before v4.0.0 release and has been deleted. This has been added back